### PR TITLE
implement open-ended reasoning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rify"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 authors = [
   "Andrew Dirksen <andrew@dirksen.com>",
   "Sam Hellawell <sshellawell@gmail.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rify"
-version = "0.6.0"
+version = "0.7.0-rc.1"
 authors = [
   "Andrew Dirksen <andrew@dirksen.com>",
   "Sam Hellawell <sshellawell@gmail.com>"

--- a/bindings/js_wasm/binding_tests/test.js
+++ b/bindings/js_wasm/binding_tests/test.js
@@ -1,4 +1,4 @@
-import { prove, validate } from 'rify';
+import { prove, validate, infer } from 'rify';
 import { expect } from 'chai';
 
 // poor man's replacement for jest because making jest work with webpack+wasm is problematic
@@ -231,6 +231,30 @@ tests([
 
     // After verifying all the assumptions in the proof are true, we know that the
     // quads in valid.implied are true with respect to the provided rules.
+  }],
+
+  ['Example from doctest for infer actually runs.', () => {
+    // (?a, is, awesome) ∧ (?a, score, ?s) -> (?a score, awesome)
+    let awesome_score_axiom = {
+      if_all: [
+        [{ Unbound: "a" }, { Bound: "is" }, { Bound: "awesome" }, { Bound: "default_graph" }],
+        [{ Unbound: "a" }, { Bound: "score" }, { Unbound: "s" }, { Bound: "default_graph" }],
+      ],
+      then: [
+        [{ Unbound: "a" }, { Bound: "score" }, { Bound: "awesome" }, { Bound: "default_graph" }]
+      ],
+    };
+    let facts = [
+      ["you", "score", "unspecified", "default_graph"],
+      ["you", "is", "awesome", "default_graph"],
+    ];
+    let new_facts = infer(facts, [awesome_score_axiom]);
+    facts = facts.concat(new_facts);
+    expect(facts).to.deep.equal([
+      ["you", "score", "unspecified", "default_graph"],
+      ["you", "is", "awesome", "default_graph"],
+      ["you", "score", "awesome", "default_graph"],
+    ]);
   }],
 ]);
 

--- a/bindings/js_wasm/package.json
+++ b/bindings/js_wasm/package.json
@@ -5,7 +5,7 @@
     "Sam Hellawell <sshellawell@gmail.com>"
   ],
   "description": "RDF reasoner that operates on RIF-like conjunctive rules. Outputs a machine\nreadable proof of some claim which can be cheaply verified.\n",
-  "version": "0.6.0",
+  "version": "0.7.0-rc.1",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",

--- a/bindings/js_wasm/package.json
+++ b/bindings/js_wasm/package.json
@@ -5,7 +5,7 @@
     "Sam Hellawell <sshellawell@gmail.com>"
   ],
   "description": "RDF reasoner that operates on RIF-like conjunctive rules. Outputs a machine\nreadable proof of some claim which can be cheaply verified.\n",
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",

--- a/bindings/js_wasm/src/js_wasm_test.rs
+++ b/bindings/js_wasm/src/js_wasm_test.rs
@@ -11,6 +11,7 @@ type ProofInput = Vec<RuleApplication<String>>;
 /// with the actual interface
 fn _types_correct(r: RulesInput, c: ClaimsInput, p: ProofInput) -> ProofInput {
     super::validate_(r.clone(), p).unwrap();
+    super::infer_(c.clone(), r.clone()).unwrap();
     super::prove_(c.clone(), c, r).unwrap()
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -28,12 +28,21 @@ where
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// A proof element that has yet to be translated to a presentable form.
+///
+/// [crate::prove::prove] function does not immediately convert LowRuleApplication's to
+/// [RuleApplication]'s. Rather, it converts only the LowRuleApplication's it is going to return
+/// to the caller.
 pub struct LowRuleApplication {
     pub rule_index: usize,
     pub instantiations: BTreeMap<usize, usize>,
 }
 
 impl LowRuleApplication {
+    /// Translate to a higher representation [RuleApplication]. The higher representation is
+    /// portable to other machines as long as those machines assume the same rule list.
+    /// This lower representation is not portable.
+    ///
     /// Panics
     ///
     /// This function will panic if:

--- a/src/common.rs
+++ b/src/common.rs
@@ -69,6 +69,9 @@ impl LowRuleApplication {
 }
 
 /// Attempt to forward translate a quad.
+/// This is a helper function. It translates all four element of a quad, calling
+/// [Translator::forward] for each element. If any element has no translation
+/// this function will return `None`.
 pub fn forward<T: Ord>(translator: &Translator<T>, key: &[T; 4]) -> Option<Quad> {
     let [s, p, o, g] = key;
     Some(
@@ -82,7 +85,9 @@ pub fn forward<T: Ord>(translator: &Translator<T>, key: &[T; 4]) -> Option<Quad>
     )
 }
 
-/// Reverse of forward.
+/// Reverse of [forward].
+/// [forward] translates each element from `T` to `usize`. This function translates each element
+/// from `usize` to `T`. If any element has no translation this function will return `None`.
 pub fn back<T: Ord>(translator: &Translator<T>, key: Quad) -> Option<[&T; 4]> {
     let Quad { s, p, o, g } = key;
     Some([

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,11 @@
+use crate::reasoner::Quad;
+use crate::rule::Rule;
+use crate::translator::Translator;
+use crate::Entity;
+use crate::RuleApplication;
+use alloc::collections::BTreeMap;
+use core::fmt::Debug;
+
 /// Increment argument then return previous value.
 ///
 /// ```nocompile
@@ -17,6 +25,76 @@ where
     let ret = a.clone();
     *a += 1u8.into();
     ret
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LowRuleApplication {
+    pub rule_index: usize,
+    pub instantiations: BTreeMap<usize, usize>,
+}
+
+impl LowRuleApplication {
+    /// Panics
+    ///
+    /// This function will panic if:
+    ///   - an unbound item from originial_rule is not instatiated by self
+    ///   - or there is no translation for a global instatiation of one of the unbound entities in
+    ///     original_rule.
+    pub fn raise<Unbound: Ord, Bound: Ord + Clone>(
+        &self,
+        original_rule: &Rule<Unbound, Bound>,
+        trans: &Translator<Bound>,
+    ) -> RuleApplication<Bound> {
+        let mut instantiations = Vec::new();
+
+        // unbound_human -> unbound_local
+        let uhul: BTreeMap<&Unbound, usize> = original_rule
+            .cononical_unbound()
+            .enumerate()
+            .map(|(i, a)| (a, i))
+            .collect();
+
+        for unbound_human in original_rule.cononical_unbound() {
+            let unbound_local: usize = uhul[unbound_human];
+            let bound_global: usize = self.instantiations[&unbound_local];
+            let bound_human: &Bound = trans.back(bound_global).unwrap();
+            instantiations.push(bound_human.clone());
+        }
+
+        RuleApplication {
+            rule_index: self.rule_index,
+            instantiations,
+        }
+    }
+}
+
+/// Attempt to forward translate a quad.
+pub fn forward<T: Ord>(translator: &Translator<T>, key: &[T; 4]) -> Option<Quad> {
+    let [s, p, o, g] = key;
+    Some(
+        [
+            translator.forward(s)?,
+            translator.forward(p)?,
+            translator.forward(o)?,
+            translator.forward(g)?,
+        ]
+        .into(),
+    )
+}
+
+/// list with repetition all bound vertices of rules and all verticies of premises
+pub fn vertices<'a, 'b, 'c, Bound, Unbound>(
+    premises: &'a [[Bound; 4]],
+    rules: &'b [Rule<Unbound, Bound>],
+) -> impl Iterator<Item = &'c Bound>
+where
+    'a: 'c,
+    'b: 'c,
+{
+    rules
+        .iter()
+        .flat_map(|rule| rule.iter_entities().filter_map(Entity::as_bound))
+        .chain(premises.iter().flatten())
 }
 
 #[cfg(test)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -82,6 +82,17 @@ pub fn forward<T: Ord>(translator: &Translator<T>, key: &[T; 4]) -> Option<Quad>
     )
 }
 
+/// Reverse of forward.
+pub fn back<T: Ord>(translator: &Translator<T>, key: Quad) -> Option<[&T; 4]> {
+    let Quad { s, p, o, g } = key;
+    Some([
+        translator.back(s.0)?,
+        translator.back(p.0)?,
+        translator.back(o.0)?,
+        translator.back(g.0)?,
+    ])
+}
+
 /// list with repetition all bound vertices of rules and all verticies of premises
 pub fn vertices<'a, 'b, 'c, Bound, Unbound>(
     premises: &'a [[Bound; 4]],

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -1,0 +1,85 @@
+use crate::common::{forward, vertices, LowRuleApplication};
+use crate::reasoner::{Quad, Reasoner};
+use crate::rule::{LowRule, Rule};
+use crate::translator::Translator;
+use crate::RuleApplication;
+use alloc::collections::BTreeSet;
+
+/// Make all possible inferences.
+pub fn infer<Unbound: Ord + Clone, Bound: Ord + Clone>(
+    premises: &[[Bound; 4]],
+    rules: &[Rule<Unbound, Bound>],
+) -> Vec<RuleApplication<Bound>> {
+    let tran: Translator<Bound> = vertices(premises, rules).cloned().collect();
+    let lpremises: Vec<Quad> = premises
+        .iter()
+        .map(|quad| forward(&tran, quad).unwrap())
+        .collect();
+    let lrules: Vec<LowRule> = rules
+        .iter()
+        .cloned()
+        .map(|rule: Rule<Unbound, Bound>| -> LowRule { rule.lower(&tran).map_err(|_| ()).unwrap() })
+        .collect();
+    low_infer(&lpremises, &lrules)
+        .iter()
+        .enumerate()
+        .map(|(i, lra)| lra.raise(&rules[i], &tran))
+        .collect()
+}
+
+/// A version of infer that operates on lowered input an returns output in lowered form.
+fn low_infer(premises: &[Quad], rules: &[LowRule]) -> Vec<LowRuleApplication> {
+    let mut rs = Reasoner::default();
+    for prem in premises {
+        rs.insert(prem.clone().into());
+    }
+
+    let mut arguments: Vec<LowRuleApplication> = Default::default();
+
+    loop {
+        let mut to_add = BTreeSet::<Quad>::new();
+        for (rule_index, rr) in rules.iter().enumerate() {
+            rs.apply(&mut rr.if_all.clone(), &mut rr.inst.clone(), &mut |inst| {
+                let mut novel = false;
+
+                let ins = inst.as_ref();
+                for implied in &rr.then {
+                    let new_quad = [
+                        ins[&implied.s.0],
+                        ins[&implied.p.0],
+                        ins[&implied.o.0],
+                        ins[&implied.g.0],
+                    ]
+                    .into();
+                    if !rs.contains(&new_quad) {
+                        novel |= to_add.insert(new_quad);
+                    }
+                }
+
+                if novel {
+                    arguments.push(LowRuleApplication {
+                        rule_index,
+                        instantiations: ins.clone(),
+                    });
+                }
+            });
+        }
+        if to_add.is_empty() {
+            break;
+        }
+        for new in to_add.into_iter() {
+            rs.insert(new);
+        }
+    }
+
+    debug_assert!(
+        {
+            let mut args = arguments.clone();
+            args.sort_unstable();
+            args.windows(2).all(|w| w[0] != w[1])
+        },
+        "results of inference should not contain duplicates"
+    );
+
+    arguments
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 extern crate core;
 
 mod common;
+mod infer;
 mod mapstack;
 mod prove;
 mod reasoner;
@@ -10,6 +11,7 @@ mod translator;
 mod validate;
 mod vecset;
 
+pub use infer::infer;
 pub use prove::{prove, CantProve, RuleApplication};
 pub use rule::{Entity, InvalidRule, Rule};
 pub use validate::{validate, Invalid, Valid};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,11 @@ pub use validate::{validate, Invalid, Valid};
 #[cfg(doctest)]
 mod test_readme {
     macro_rules! external_doc_test {
-    ($x:expr) => {
-        #[doc = $x]
-        extern {}
-    };
-  }
+        ($x:expr) => {
+            #[doc = $x]
+            extern "C" {}
+        };
+    }
 
     external_doc_test!(include_str!("../README.md"));
 }

--- a/src/prove.rs
+++ b/src/prove.rs
@@ -211,6 +211,37 @@ impl std::error::Error for CantProve {}
 
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+/// An element of a deductive proof. Proofs can be transmitted and later validatated as long as the
+/// validator assumes the same rule list as the prover.
+///
+/// Unbound variables are bound to the values in `instanitations`. They are bound in order of
+/// initial appearance.
+///
+/// Given the rule:
+///
+/// ```customlang
+/// ifall
+///   [?z ex:foo ?x DG]
+/// then
+///   [?x ex:bar ?z DG]
+/// ```
+///
+/// and the RuleApplication:
+///
+/// ```customlang
+/// RuleApplication {
+///   rule_index: 0,
+///   instantiations: vec!["foer", "bary"],
+/// }
+/// ```
+///
+/// The rule application represents the deductive proof:
+///
+/// ```customlang
+/// [foer ex:foo bary DG]
+/// therefore
+/// [bary ex:bar foer DG]
+/// ```
 pub struct RuleApplication<Bound> {
     /// The index of the rule in the implicitly associated rule list.
     pub rule_index: usize,

--- a/src/reasoner.rs
+++ b/src/reasoner.rs
@@ -197,6 +197,18 @@ impl Reasoner {
         let (strictest, less_strict) = rule.split_first_mut().expect("rule to be non-empty");
         Some((strictest, less_strict))
     }
+
+    /// Get the deduplicated history of all claims that were inserted into this reasoner.
+    /// The returned list will be in insertion order.
+    pub fn claims(self) -> Vec<Quad> {
+        self.claims
+    }
+
+    /// Get the deduplicated history of all claims that were inserted into this reasoner.
+    /// The returned list will be in insertion order.
+    pub fn claims_ref(&self) -> &[Quad] {
+        &self.claims
+    }
 }
 
 trait Indexed {
@@ -482,6 +494,22 @@ mod tests {
             .chain(initial_claims.iter().cloned())
             .collect();
         assert_eq!(claims, expected_claims);
+    }
+
+    #[test]
+    fn claims() {
+        let mut rs = Reasoner::default();
+        for quad in &[[1, 1, 1, 1], [1, 2, 2, 2], [1, 1, 1, 1], [1, 3, 3, 3]] {
+            rs.insert(quad.clone().into());
+        }
+        assert_eq!(
+            &rs.claims(),
+            &[
+                [1, 1, 1, 1].into(),
+                [1, 2, 2, 2].into(),
+                [1, 3, 3, 3].into()
+            ],
+        );
     }
 
     /// panics if an unbound name is implied


### PR DESCRIPTION
This pr adds a new function. `infer`

`infer` doesn't have a goal in mind like `prove` does.
Unlike `validate`, `infer` thinks for itself. It generates its own conclusions.
`infer` is an open minded individual who won't stop until it groks its universe in full.

:)