### PR TITLE
Optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rify"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
   "Andrew Dirksen <andrew@dirksen.com>",
   "Sam Hellawell <sshellawell@gmail.com>"

--- a/benches/.gitignore
+++ b/benches/.gitignore
@@ -1,0 +1,5 @@
+/target
+/pkg
+/wasm-pack.log
+/tmp
+/Cargo.lock

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "benches"
+version = "0.1.0"
+authors = ["Andrew Dirksen <andrew@dirksen.com>"]
+edition = "2018"
+
+[dependencies]
+rify = { path = ".." }

--- a/benches/rust-toolchain
+++ b/benches/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -32,8 +32,8 @@ mod ancestry {
     }
 
     // Contains intentional leak; don't use outside of tests.
-    fn facts() -> Vec<[&'static str; 4]> {
-        let nodes: Vec<&str> = (0..20)
+    fn facts(numnodes: usize) -> Vec<[&'static str; 4]> {
+        let nodes: Vec<&str> = (0..numnodes)
             .map(|n| Box::leak(format!("node_{}", n).into_boxed_str()) as &str)
             .collect();
         let facts: Vec<[&str; 4]> = nodes
@@ -46,16 +46,30 @@ mod ancestry {
 
     #[bench]
     fn infer_(b: &mut Bencher) {
-        let facts = facts();
+        let facts = facts(20);
         let rules = rules();
         b.iter(|| infer(&facts, &rules));
     }
 
     #[bench]
     fn prove_(b: &mut Bencher) {
-        let facts = facts();
+        let facts = facts(20);
         let rules = rules();
-        b.iter(|| prove(&facts, &[[PARENT, PARENT, PARENT, PARENT]], &rules));
+        b.iter(|| prove(&facts, &[[PARENT, PARENT, PARENT, PARENT]], &rules).unwrap_err());
+    }
+
+    #[bench]
+    fn infer_30(b: &mut Bencher) {
+        let facts = facts(30);
+        let rules = rules();
+        b.iter(|| infer(&facts, &rules));
+    }
+
+    #[bench]
+    fn prove_30(b: &mut Bencher) {
+        let facts = facts(30);
+        let rules = rules();
+        b.iter(|| prove(&facts, &[[PARENT, PARENT, PARENT, PARENT]], &rules).unwrap_err());
     }
 }
 

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,0 +1,123 @@
+#![cfg(test)]
+#![feature(test)]
+
+extern crate test;
+
+use core::fmt::Debug;
+use rify::Entity::{Bound as B, Unbound as U};
+use rify::*;
+use test::Bencher;
+
+const DG: &str = "default_graph";
+
+mod ancestry {
+    use super::*;
+    const PARENT: &str = "parent";
+    const ANCESTOR: &str = "ancestor";
+
+    fn rules() -> Vec<rify::Rule<&'static str, &'static str>> {
+        decl_rules(&[
+            [
+                &[[U("a"), B(PARENT), U("b"), B(DG)]],
+                &[[U("a"), B(ANCESTOR), U("b"), B(DG)]],
+            ],
+            [
+                &[
+                    [U("a"), B(ANCESTOR), U("b"), B(DG)],
+                    [U("b"), B(ANCESTOR), U("c"), B(DG)],
+                ],
+                &[[U("a"), B(ANCESTOR), U("c"), B(DG)]],
+            ],
+        ])
+    }
+
+    // Contains intentional leak; don't use outside of tests.
+    fn facts() -> Vec<[&'static str; 4]> {
+        let nodes: Vec<&str> = (0..20)
+            .map(|n| Box::leak(format!("node_{}", n).into_boxed_str()) as &str)
+            .collect();
+        let facts: Vec<[&str; 4]> = nodes
+            .iter()
+            .zip(nodes.iter().cycle().skip(1))
+            .map(|(a, b)| [a, PARENT, b, DG])
+            .collect();
+        facts
+    }
+
+    #[bench]
+    fn infer_(b: &mut Bencher) {
+        let facts = facts();
+        let rules = rules();
+        b.iter(|| infer(&facts, &rules));
+    }
+
+    #[bench]
+    fn prove_(b: &mut Bencher) {
+        let facts = facts();
+        let rules = rules();
+        b.iter(|| prove(&facts, &[[PARENT, PARENT, PARENT, PARENT]], &rules));
+    }
+}
+
+mod recursion_minimal {
+    use super::*;
+
+    const RULES: &[[&[[rify::Entity<&str, &str>; 4]]; 2]] = &[
+        [
+            &[
+                [B("andrew"), B("claims"), U("c"), B(DG)],
+                [U("c"), B("subject"), U("s"), B(DG)],
+                [U("c"), B("property"), U("p"), B(DG)],
+                [U("c"), B("object"), U("o"), B(DG)],
+            ],
+            &[[U("s"), U("p"), U("o"), B(DG)]],
+        ],
+        [
+            &[
+                [U("person_a"), B("is"), B("awesome"), B(DG)],
+                [U("person_a"), B("friendswith"), U("person_b"), B(DG)],
+            ],
+            &[[U("person_b"), B("is"), B("awesome"), B(DG)]],
+        ],
+        [
+            &[[U("person_a"), B("friendswith"), U("person_b"), B(DG)]],
+            &[[U("person_b"), B("friendswith"), U("person_a"), B(DG)]],
+        ],
+    ];
+
+    const FACTS: &[[&str; 4]] = &[
+        ["soyoung", "friendswith", "nick", DG],
+        ["nick", "friendswith", "elina", DG],
+        ["elina", "friendswith", "sam", DG],
+        ["sam", "friendswith", "fausto", DG],
+        ["fausto", "friendswith", "lovesh", DG],
+        ["andrew", "claims", "_:claim1", DG],
+        ["_:claim1", "subject", "lovesh", DG],
+        ["_:claim1", "property", "is", DG],
+        ["_:claim1", "object", "awesome", DG],
+    ];
+
+    #[bench]
+    fn infer_(b: &mut Bencher) {
+        let rules = decl_rules(RULES);
+        b.iter(|| infer(FACTS, &rules));
+    }
+
+    #[bench]
+    fn prove_(b: &mut Bencher) {
+        let rules = decl_rules(RULES);
+        let composite_claims: &[[&str; 4]] = &[
+            ["soyoung", "is", "awesome", "default_graph"],
+            ["nick", "is", "awesome", "default_graph"],
+        ];
+        b.iter(|| prove(FACTS, composite_claims, &rules));
+    }
+}
+
+pub fn decl_rules<Unbound: Ord + Debug + Clone, Bound: Ord + Clone>(
+    rs: &[[&[[rify::Entity<Unbound, Bound>; 4]]; 2]],
+) -> Vec<rify::Rule<Unbound, Bound>> {
+    rs.iter()
+        .map(|[ifa, then]| rify::Rule::create(ifa.to_vec(), then.to_vec()).unwrap())
+        .collect()
+}

--- a/bindings/js_wasm/package.json
+++ b/bindings/js_wasm/package.json
@@ -5,7 +5,7 @@
     "Sam Hellawell <sshellawell@gmail.com>"
   ],
   "description": "RDF reasoner that operates on RIF-like conjunctive rules. Outputs a machine\nreadable proof of some claim which can be cheaply verified.\n",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",

--- a/justfile
+++ b/justfile
@@ -31,15 +31,35 @@ js-test:
 clean:
   cargo clean
   cd benches; cargo clean
-  rm -r bindings/js_wasm/pkg || true
+  rm -rf bindings/js_wasm/pkg
   just clean-js
 
 # remove artifacts from js bindings tests
 clean-js:
-  rm -r bindings/js_wasm/binding_tests/dist || true
-  rm -r bindings/js_wasm/binding_tests/node_modules || true
+  rm -rf bindings/js_wasm/binding_tests/dist
+  rm -rf bindings/js_wasm/binding_tests/node_modules
 
 bench:
   #!/usr/bin/env bash
   cd benches
   cargo bench
+
+checkall-buildall:
+  just clean
+  cargo test
+  cargo clippy -- -D warnings
+  just bench
+  just js-test
+
+assert-clean-workdir:
+  ! test -n "$(git status --porcelain)" # please commit before publish
+
+publish-js:
+  just checkall-buildall
+  just assert-clean-workdir
+  cd bindings/js_wasm/pkg && npm publish
+
+publish-rs:
+  just checkall-buildall
+  just assert-clean-workdir
+  cargo publish

--- a/justfile
+++ b/justfile
@@ -30,6 +30,7 @@ js-test:
 # remove dist and node_modules from js bindings tests
 clean:
   cargo clean
+  cd benches; cargo clean
   rm -r bindings/js_wasm/pkg || true
   just clean-js
 
@@ -37,3 +38,8 @@ clean:
 clean-js:
   rm -r bindings/js_wasm/binding_tests/dist || true
   rm -r bindings/js_wasm/binding_tests/node_modules || true
+
+bench:
+  #!/usr/bin/env bash
+  cd benches
+  cargo bench

--- a/src/common.rs
+++ b/src/common.rs
@@ -33,9 +33,9 @@ where
 /// [crate::prove::prove] function does not immediately convert LowRuleApplication's to
 /// [RuleApplication]'s. Rather, it converts only the LowRuleApplication's it is going to return
 /// to the caller.
-pub struct LowRuleApplication {
+pub(crate) struct LowRuleApplication {
     pub rule_index: usize,
-    pub instantiations: BTreeMap<usize, usize>,
+    pub instantiations: Vec<Option<usize>>,
 }
 
 impl LowRuleApplication {
@@ -65,7 +65,7 @@ impl LowRuleApplication {
 
         for unbound_human in original_rule.cononical_unbound() {
             let unbound_local: usize = uhul[unbound_human];
-            let bound_global: usize = self.instantiations[&unbound_local];
+            let bound_global: usize = self.instantiations.get(unbound_local).unwrap().unwrap();
             let bound_human: &Bound = trans.back(bound_global).unwrap();
             instantiations.push(bound_human.clone());
         }
@@ -81,7 +81,7 @@ impl LowRuleApplication {
 /// This is a helper function. It translates all four element of a quad, calling
 /// [Translator::forward] for each element. If any element has no translation
 /// this function will return `None`.
-pub fn forward<T: Ord>(translator: &Translator<T>, key: &[T; 4]) -> Option<Quad> {
+pub(crate) fn forward<T: Ord>(translator: &Translator<T>, key: &[T; 4]) -> Option<Quad> {
     let [s, p, o, g] = key;
     Some(
         [
@@ -97,7 +97,7 @@ pub fn forward<T: Ord>(translator: &Translator<T>, key: &[T; 4]) -> Option<Quad>
 /// Reverse of [forward].
 /// [forward] translates each element from `T` to `usize`. This function translates each element
 /// from `usize` to `T`. If any element has no translation this function will return `None`.
-pub fn back<T: Ord>(translator: &Translator<T>, key: Quad) -> Option<[&T; 4]> {
+pub(crate) fn back<T: Ord>(translator: &Translator<T>, key: Quad) -> Option<[&T; 4]> {
     let Quad { s, p, o, g } = key;
     Some([
         translator.back(s.0)?,

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -65,15 +65,8 @@ fn low_infer(premises: &[Quad], rules: &[LowRule]) -> Vec<Quad> {
             } in rules.iter_mut()
             {
                 rs.apply_related(new.clone(), if_all, inst, &mut |inst| {
-                    let ins = inst.as_ref();
-                    for implied in then.iter() {
-                        let new_quad = [
-                            ins[&implied.s.0],
-                            ins[&implied.p.0],
-                            ins[&implied.o.0],
-                            ins[&implied.g.0],
-                        ]
-                        .into();
+                    for implied in then.iter().cloned() {
+                        let new_quad = implied.local_to_global(inst).unwrap();
                         if !rs.contains(&new_quad) && !adding.contains(&new_quad) {
                             to_add.insert(new_quad);
                         }

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -28,36 +28,58 @@ pub fn infer<Unbound: Ord + Clone, Bound: Ord + Clone>(
 /// A version of infer that operates on lowered input an returns output in lowered form.
 fn low_infer(premises: &[Quad], rules: &[LowRule]) -> Vec<Quad> {
     let mut rs = Reasoner::default();
-    for prem in premises {
-        rs.insert(prem.clone());
-    }
-    let initial_len = rs.claims_ref().len(); // number of premises after dedup
-    debug_assert!(initial_len <= premises.len());
 
-    loop {
-        let mut to_add = BTreeSet::<Quad>::new();
-        for rr in rules.iter() {
-            rs.apply(&mut rr.if_all.clone(), &mut rr.inst.clone(), &mut |inst| {
-                let ins = inst.as_ref();
-                for implied in &rr.then {
-                    let new_quad = [
-                        ins[&implied.s.0],
-                        ins[&implied.p.0],
-                        ins[&implied.o.0],
-                        ins[&implied.g.0],
-                    ]
-                    .into();
-                    if !rs.contains(&new_quad) {
-                        to_add.insert(new_quad);
-                    }
-                }
-            });
+    let mut to_add: BTreeSet<Quad> = premises.iter().cloned().collect();
+    let initial_len = to_add.len(); // number of premises after dedup
+    assert!(initial_len <= premises.len());
+
+    // apply_related is sufficient except for in the case of unconditional rules.
+    // in order to avoid calling apply() directly, rules with empty "if" clauses
+    // lists will get special treatment.
+    for rule in rules {
+        if rule.if_all.is_empty() {
+            for rule_part in &rule.then {
+                to_add.insert(rule_part.clone().local_to_global(&rule.inst).unwrap());
+            }
         }
+    }
+    let mut rules: Vec<LowRule> = rules
+        .iter()
+        .filter(|r| !r.if_all.is_empty())
+        .cloned()
+        .collect();
+
+    // subsequent reasoning is done in a loop using apply_related
+    loop {
         if to_add.is_empty() {
             break;
         }
-        for new in to_add.into_iter() {
-            rs.insert(new);
+        let mut adding = BTreeSet::default();
+        core::mem::swap(&mut to_add, &mut adding);
+        for new in adding.iter().cloned() {
+            rs.insert(new.clone());
+            for LowRule {
+                ref mut if_all,
+                then,
+                ref mut inst,
+            } in rules.iter_mut()
+            {
+                rs.apply_related(new.clone(), if_all, inst, &mut |inst| {
+                    let ins = inst.as_ref();
+                    for implied in then.iter() {
+                        let new_quad = [
+                            ins[&implied.s.0],
+                            ins[&implied.p.0],
+                            ins[&implied.o.0],
+                            ins[&implied.g.0],
+                        ]
+                        .into();
+                        if !rs.contains(&new_quad) && !adding.contains(&new_quad) {
+                            to_add.insert(new_quad);
+                        }
+                    }
+                });
+            }
         }
     }
 

--- a/src/mapstack.rs
+++ b/src/mapstack.rs
@@ -1,51 +1,58 @@
-use alloc::collections::BTreeMap;
 use core::fmt;
 use core::fmt::Debug;
 use core::iter::FromIterator;
 
 /// A mapping that keeps a history of writes. Writes to the map effect "pushes" to a stack. Those
 /// "pushes" can be undone with a "pop".
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MapStack<K, V> {
-    current: BTreeMap<K, V>,
-    history: Vec<(K, Option<V>)>,
+///
+/// Beware large keys when using this data structure. The memory used byt this structure scales
+/// with the size of the largest key!
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Default)]
+pub(crate) struct MapStack<V> {
+    current: Vec<Option<V>>,
+    history: Vec<(usize, Option<V>)>,
 }
 
-impl<K: Ord, V> MapStack<K, V> {
+impl<V> MapStack<V> {
     pub fn new() -> Self {
         Self {
-            current: BTreeMap::new(),
+            current: Vec::new(),
             history: Vec::new(),
         }
     }
 }
 
-impl<K: Ord + Clone, V> MapStack<K, V> {
+impl<V> MapStack<V> {
     /// Set a value appending to write history.
-    pub fn write(&mut self, key: K, val: V) {
-        let old_val = self.current.insert(key.clone(), val);
-        self.history.push((key, old_val));
+    pub fn write(&mut self, key: usize, val: V) {
+        debug_assert!(key < 30 ^ 2, "Thats a pretty large key. Are you sure?");
+        if self.current.len() <= key {
+            self.current.resize_with(key + 1, || None);
+        }
+        let mut val = Some(val);
+        core::mem::swap(&mut self.current[key], &mut val);
+        self.history.push((key, val));
     }
 
     /// Undo most recent write or return error if there is no history to undo.
     pub fn undo(&mut self) -> Result<(), NoMoreHistory> {
         let (key, old_val) = self.history.pop().ok_or(NoMoreHistory)?;
-        match old_val {
-            Some(val) => self.current.insert(key, val),
-            None => self.current.remove(&key),
-        };
+        self.current[key] = old_val;
         Ok(())
     }
-}
 
-impl<K, V> AsRef<BTreeMap<K, V>> for MapStack<K, V> {
-    fn as_ref(&self) -> &BTreeMap<K, V> {
+    /// Get the current value at key.
+    pub fn get(&self, key: usize) -> Option<&V> {
+        self.current.get(key).and_then(|o| o.as_ref())
+    }
+
+    pub fn inner(&self) -> &Vec<Option<V>> {
         &self.current
     }
 }
 
-impl<K: Ord + Clone, V> FromIterator<(K, V)> for MapStack<K, V> {
-    fn from_iter<T: IntoIterator<Item = (K, V)>>(kvs: T) -> Self {
+impl<V> FromIterator<(usize, V)> for MapStack<V> {
+    fn from_iter<T: IntoIterator<Item = (usize, V)>>(kvs: T) -> Self {
         let mut ret = Self::new();
         for (k, v) in kvs.into_iter() {
             ret.write(k, v);

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -27,19 +27,6 @@ pub(crate) struct LowRule {
     pub inst: Instantiations, // partially maps the local scope to some global scope
 }
 
-// impl LowRule {
-//     /// List all implications as globaly scoped quads.
-//     ///
-//     /// # Panics
-//     ///
-//     /// Panics if rule is not sufficiently instantiated.
-//     pub fn instantiated(&self) -> impl Iterator<Item = Quad> {
-//         let inst = self.inst.as_ref();
-//         self.then.iter().map(|local| {
-//         })
-//     }
-// }
-
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Entity<Unbound, Bound> {
@@ -298,8 +285,7 @@ mod test {
                 .map(|local_name| {
                     re_rulea
                         .inst
-                        .as_ref()
-                        .get(&local_name)
+                        .get(*local_name)
                         .map(|global_name| trans.back(*global_name).unwrap().clone())
                 })
                 .collect();
@@ -353,8 +339,7 @@ mod test {
                 .map(|local_name| {
                     re_ruleb
                         .inst
-                        .as_ref()
-                        .get(&local_name)
+                        .get(*local_name)
                         .map(|global_name| trans.back(*global_name).unwrap().clone())
                 })
                 .collect();

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -27,6 +27,19 @@ pub(crate) struct LowRule {
     pub inst: Instantiations, // partially maps the local scope to some global scope
 }
 
+// impl LowRule {
+//     /// List all implications as globaly scoped quads.
+//     ///
+//     /// # Panics
+//     ///
+//     /// Panics if rule is not sufficiently instantiated.
+//     pub fn instantiated(&self) -> impl Iterator<Item = Quad> {
+//         let inst = self.inst.as_ref();
+//         self.then.iter().map(|local| {
+//         })
+//     }
+// }
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Entity<Unbound, Bound> {


### PR DESCRIPTION
This pr includes benchmarks and optimizations for `prove()` and `infer()`.

- [x] benchmarks
- [x] [differential rule applications](https://github.com/docknetwork/rify/issues/1)
- [x] reduce cloning of rules in reasoning hot-path
- [x] [MapStack lookup optimization](https://github.com/docknetwork/rify/issues/9)

See commit log for benchmark comparisons.